### PR TITLE
Fixes name of the command string printed

### DIFF
--- a/make.js
+++ b/make.js
@@ -191,7 +191,7 @@ function nextJob() {
 	   console.log('running ' + instCmd);
 	   
 	   var gzip = 'gzip -c ' + output + ' > ' + output + '.gz';
-	   console.log('running ' + instCmd);
+	   console.log('running ' + gzip);
 	   
 	   var all = instCmd + ';' + gzip;
 	   exec(all, onExec);


### PR DESCRIPTION
Believe it is a typo to print instCmd twice.