### PR TITLE
Fixes passing of parameter to JS function

### DIFF
--- a/src/wildwebmidi.c
+++ b/src/wildwebmidi.c
@@ -632,9 +632,7 @@ int wildwebmidi(char* midi_file, char* wav_file, int sleep) {
 }
 
 static void completeConversion(int status) {
-    EM_ASM(
-        completeConversion(status);
-    );
+    EM_ASM(completeConversion($0), status);
 }
 
 


### PR DESCRIPTION
According the [emscripten docs](https://emscripten.org/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.html#interacting-with-code-call-javascript-from-native) parameter need to be passed to javascript this way.